### PR TITLE
[readme] Fixed broken links to other READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,5 @@ Collection of Paradex code samples and snippets
 
 ## Examples
 
-* [Onboarding and Authentication](examples/README.md#onboarding-and-authentication)
+* [Go](examples/go/README.md)
+* [Python](examples/python/README.md)

--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ Collection of Paradex code samples and snippets
 
 * [Go](examples/go/README.md)
 * [Python](examples/python/README.md)
+
+## Benchmarks
+
+* [Order Signing Benchmarks](benchmarks/README.md)


### PR DESCRIPTION
The link on the main README was broken, so instead I make two links -
one to the GO code and one to Python.

Testing: none
jira: skip
