### PR TITLE
[ts] Fix order signature for market orders

### DIFF
--- a/typescript/src/utils/signature.ts
+++ b/typescript/src/utils/signature.ts
@@ -80,7 +80,7 @@ export function signOrder(
 ): string {
   const sideForSigning = orderDetails.side === "BUY" ? "1" : "2";
 
-  const priceForSigning = toQuantums(orderDetails.price, 8);
+  const priceForSigning = toQuantums(orderDetails.price ?? "0", 8);
   const sizeForSigning = toQuantums(orderDetails.size, 8);
   const orderTypeForSigning = shortString.encodeShortString(orderDetails.type);
   const marketForSigning = shortString.encodeShortString(orderDetails.market);


### PR DESCRIPTION
Market orders do not take a price, but the order signature requires it for all types of orders. In case of market orders, the price must be set to 0.

This change updates the order signing function to set the price to sign to 0 when it's not set.