### PR TITLE
[go] Replace caigo with gnark-crypto for signing

### DIFF
--- a/go/onboarding.go
+++ b/go/onboarding.go
@@ -5,11 +5,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math/big"
 	"net/http"
 	"os"
 	"strconv"
 	"time"
 
+	starkcurve "github.com/consensys/gnark-crypto/ecc/stark-curve"
+	"github.com/consensys/gnark-crypto/ecc/stark-curve/ecdsa"
+	"github.com/consensys/gnark-crypto/ecc/stark-curve/fr"
 	"github.com/dontpanicdao/caigo"
 	"github.com/dontpanicdao/caigo/types"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -53,6 +57,34 @@ func GenerateParadexAccount(config SystemConfigResponse, ethPrivateKey string) (
 	return dexPrivateKey, dexPublicKey, dexAccountAddress
 }
 
+// Get ECDSA private key from string
+func GetEcdsaPrivateKey(pk string) *ecdsa.PrivateKey {
+	privateKey := types.StrToFelt(pk).Big()
+
+	// Generate public key
+	_, g := starkcurve.Generators()
+	ecdsaPublicKey := new(ecdsa.PublicKey)
+	ecdsaPublicKey.A.ScalarMultiplication(&g, privateKey)
+
+	// Generate private key
+	pkBytes := privateKey.FillBytes(make([]byte, fr.Bytes))
+	buf := append(ecdsaPublicKey.Bytes(), pkBytes...)
+	ecdsaPrivateKey := new(ecdsa.PrivateKey)
+	ecdsaPrivateKey.SetBytes(buf)
+	return ecdsaPrivateKey
+}
+
+func GnarkSign(messageHash *big.Int, privateKey string) (r, s *big.Int, err error) {
+	ecdsaPrivateKey := GetEcdsaPrivateKey(privateKey)
+	sigBin, err := ecdsaPrivateKey.Sign(messageHash.Bytes(), nil)
+	if err != nil {
+		return nil, nil, err
+	}
+	r = new(big.Int).SetBytes(sigBin[:fr.Bytes])
+	s = new(big.Int).SetBytes(sigBin[fr.Bytes:])
+	return r, s, nil
+}
+
 // `POST /onboarding`
 func PerformOnboarding(
 	config SystemConfigResponse,
@@ -63,13 +95,12 @@ func PerformOnboarding(
 
 ) {
 	dexAccountAddressBN := types.HexToBN(dexAccountAddress)
-	dexPrivateKeyBN := types.HexToBN(dexPrivateKey)
 
 	// Get message hash and signature
 	message := &OnboardingPayload{Action: "Onboarding"}
 	typedData, _ := NewVerificationTypedData(VerificationTypeOnboarding, config.ChainId)
 	messageHash, _ := typedData.GetMessageHash(dexAccountAddressBN, message, caigo.StarkCurve{})
-	r, s, _ := caigo.Curve.Sign(messageHash, dexPrivateKeyBN)
+	r, s, _ := GnarkSign(messageHash, dexPrivateKey)
 
 	// URL
 	onboardingUrl := fmt.Sprintf("%s/onboarding", PARADEX_HTTP_URL)
@@ -99,7 +130,6 @@ func GetJwtToken(
 	dexPrivateKey string,
 ) string {
 	dexAccountAddressBN := types.HexToBN(dexAccountAddress)
-	dexPrivateKeyBN := types.HexToBN(dexPrivateKey)
 
 	// Get timestamp and expiration
 	now := time.Now().Unix()
@@ -116,7 +146,7 @@ func GetJwtToken(
 	}
 	typedData, _ := NewVerificationTypedData(VerificationTypeAuth, config.ChainId)
 	messageHash, _ := typedData.GetMessageHash(dexAccountAddressBN, message, caigo.StarkCurve{})
-	r, s, _ := caigo.Curve.Sign(messageHash, dexPrivateKeyBN)
+	r, s, _ := GnarkSign(messageHash, dexPrivateKey)
 
 	// URL
 	authUrl := fmt.Sprintf("%s/auth", PARADEX_HTTP_URL)
@@ -162,6 +192,38 @@ func GetOpenOrders(jwtToken string) []*Order {
 
 	orders := ParseGetOrders(res)
 	return orders
+}
+
+func ExampleSignOrder() {
+	privateKey := GetEcdsaPrivateKey("X")
+	accountAddress := big.NewInt(0)
+	sc := caigo.StarkCurve{}
+	td, _ := NewVerificationTypedData("Order", "PRIVATE_SN_POTC_SEPOLIA")
+	domEnc, _ := td.GetTypedMessageHash("StarkNetDomain", td.Domain, sc)
+
+	for j := 0; j < 10; j++ {
+		start := time.Now()
+		for i := 0; i < 100000; i++ {
+			orderP := &OrderPayload{
+				Timestamp: time.Now().Unix(),
+				Market:    "BTC-USD-PERP",
+				Side:      "BUY",
+				OrderType: "LIMIT",
+				Size:      strconv.Itoa(20 + i),
+				Price:     strconv.Itoa(1900 + i),
+			}
+			messageHash, _ := GnarkGetMessageHash(td, domEnc, accountAddress, orderP, sc)
+			sigBin, err := privateKey.Sign(messageHash.Bytes(), nil)
+			if err != nil {
+				fmt.Println(err)
+			}
+			valid, _ := privateKey.PublicKey.Verify(sigBin, messageHash.Bytes(), nil)
+			if !valid {
+				fmt.Println("Invalid signature")
+			}
+		}
+		fmt.Println(time.Since(start).Seconds() / 100000)
+	}
 }
 
 func main() {

--- a/go/signable_starknet_test.go
+++ b/go/signable_starknet_test.go
@@ -7,181 +7,86 @@ import (
 	"testing"
 
 	"github.com/consensys/gnark-crypto/ecc/stark-curve/ecdsa"
-	"github.com/consensys/gnark-crypto/ecc/stark-curve/fp"
 
 	"github.com/dontpanicdao/caigo"
-	"github.com/dontpanicdao/caigo/types"
 	"github.com/stretchr/testify/require"
-
-	pedersenhash "github.com/consensys/gnark-crypto/ecc/stark-curve/pedersen-hash"
 )
 
-var snMessageBigInt = types.UTF8StrToBig("StarkNet Message")
+const StarknetChainID = "PRIVATE_SN_POTC_SEPOLIA" // TESTNET
 
-func GetMessageHash(td *caigo.TypedData, domEnc *big.Int, account *big.Int, msg caigo.TypedMessage, sc caigo.StarkCurve) (hash *big.Int, err error) {
-	elements := []*big.Int{snMessageBigInt, domEnc, account, nil}
-
-	msgEnc, err := td.GetTypedMessageHash(td.PrimaryType, msg, sc)
-	if err != nil {
-		return hash, fmt.Errorf("could not hash message: %w", err)
-	}
-	elements[3] = msgEnc
-	hash, err = sc.ComputeHashOnElements(elements)
-	return hash, err
+var orderPayload = &OrderPayload{
+	Timestamp: 1684815490129,
+	Market:    "ETH-USD-PERP",
+	Side:      "BUY",
+	OrderType: "LIMIT",
+	Size:      "2000000000",   // 20 * 10^8
+	Price:     "190000000000", // 1900 * 10^8
 }
+var testAccountAddress = big.NewInt(0) // Replace with account address
 
 func BenchmarkSignSingleOrder(b *testing.B) {
-	orderP := &OrderPayload{
-		Timestamp: 1684815490129,
-		Market:    "ETH-USD-PERP",
-		Side:      "SELL",
-		OrderType: "LIMIT",
-		Size:      "2000000000",   // 20 * 10^8
-		Price:     "190000000000", // 1900 * 10^8
-	}
 	priv, _ := caigo.Curve.GetRandomPrivateKey()
-	// priv, _ := big.NewInt(0).SetString("83490221354900822813770954017753999002387366720326019591623250615955802248", 10)
 	x, y, err := caigo.Curve.PrivateToPoint(priv)
 	require.NoError(b, err)
-	td, err := NewVerificationTypedData(VerificationTypeOrder, "PRIVATE_SN_POTC_SEPOLIA")
+	td, err := NewVerificationTypedData(VerificationTypeOrder, StarknetChainID)
 	require.NoError(b, err)
 	sc := caigo.StarkCurve{}
 	domEnc, err := td.GetTypedMessageHash("StarkNetDomain", td.Domain, sc)
 	require.NoError(b, err)
-	// x is the Public Key
-	// Replace x with account address
-	// Compute using `ComputeAddress` method in `go/utils.go:40`
 
 	var r, s *big.Int
 	sum := big.NewInt(0)
 	b.ResetTimer()
 	var hash *big.Int
 	for i := 0; i < b.N; i++ {
-		hash, err := GetMessageHash(td, domEnc, x, orderP, sc)
+		hash, err = GetMessageHash(td, domEnc, testAccountAddress, orderPayload, sc)
 		require.NoError(b, err)
 		r, s, err = caigo.Curve.Sign(hash, priv)
 		require.NoError(b, err)
 		sum = sum.Add(r, s)
 	}
 	b.StopTimer()
-	if hash == nil {
-		return
-	}
 
-	if caigo.Curve.Verify(hash, r, s, x, y) {
-		fmt.Println("signature is valid")
-	} else {
-		fmt.Println("signature is invalid")
+	if hash != nil {
+		valid := caigo.Curve.Verify(hash, r, s, x, y)
+		fmt.Println("Valid signature:", valid)
 	}
 }
 
 func BenchmarkVerifySingleOrder(b *testing.B) {
-	orderP := &OrderPayload{
-		Timestamp: 1684815490129,
-		Market:    "ETH-USD-PERP",
-		Side:      "SELL",
-		OrderType: "LIMIT",
-		Size:      "2000000000",   // 20 * 10^8
-		Price:     "190000000000", // 1900 * 10^8
-	}
-	priv, _ := caigo.Curve.GetRandomPrivateKey()
-
+	priv, err := caigo.Curve.GetRandomPrivateKey()
+	require.NoError(b, err)
 	pubX, _, err := caigo.Curve.PrivateToPoint(priv)
 	require.NoError(b, err)
-	td, err := NewVerificationTypedData(VerificationTypeOrder, "PRIVATE_SN_POTC_SEPOLIA")
+	td, err := NewVerificationTypedData(VerificationTypeOrder, StarknetChainID)
 	require.NoError(b, err)
 	sc := caigo.StarkCurve{}
 	domEnc, err := td.GetTypedMessageHash("StarkNetDomain", td.Domain, sc)
-	require.NoError(b, err)
-	// x is the Public Key
-	// Replace x with account address
-	// Compute using `ComputeAddress` method in `go/utils.go:40`
-	// hash, err := GetMessageHash(td, domEnc, pubX, orderP, sc)
-	require.NoError(b, err)
-	// r, s, err := caigo.Curve.Sign(hash, priv)
 	require.NoError(b, err)
 
 	sum := big.NewInt(0)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		hash, err := GetMessageHash(td, domEnc, pubX, orderP, sc)
+		hash, err := GetMessageHash(td, domEnc, pubX, orderPayload, sc)
 		require.NoError(b, err)
-		// valid := caigo.Curve.Verify(hash, r, s, pubX, pubY)
-		// require.True(b, valid)
 		sum = sum.Add(sum, hash)
 	}
 }
 
-func PedersenArray(elems []*big.Int) *big.Int {
-	fpElements := make([]*fp.Element, len(elems))
-	for i, elem := range elems {
-		f := &fp.Element{}
-		fpElements[i] = f.SetBigInt(elem)
-	}
-	hash := pedersenhash.PedersenArray(fpElements...)
-	res := big.NewInt(0)
-	return hash.BigInt(res)
-}
-
-func GnarkGetMessageHash(td *caigo.TypedData, domEnc *big.Int, account *big.Int, msg caigo.TypedMessage, sc caigo.StarkCurve) (hash *big.Int, err error) {
-	elements := []*big.Int{snMessageBigInt, domEnc, account, nil}
-
-	msgEnc, err := GnarkGetTypedMessageHash(td, td.PrimaryType, msg)
-	if err != nil {
-		return hash, fmt.Errorf("could not hash message: %w", err)
-	}
-	elements[3] = msgEnc
-	hash = PedersenArray(elements)
-	return hash, err
-}
-
-func GnarkGetTypedMessageHash(td *caigo.TypedData, inType string, msg caigo.TypedMessage) (hash *big.Int, err error) {
-	prim := td.Types[inType]
-	elements := []*big.Int{prim.Encoding}
-
-	for _, def := range prim.Definitions {
-		if def.Type == "felt" {
-			fmtDefinitions := msg.FmtDefinitionEncoding(def.Name)
-			elements = append(elements, fmtDefinitions...)
-			continue
-		} else {
-			panic("not felt")
-		}
-	}
-	hash = PedersenArray(elements)
-	return hash, err
-}
-
 func BenchmarkGnarkSignSingleOrder(b *testing.B) {
-	orderP := &OrderPayload{
-		Timestamp: 1684815490129,
-		Market:    "ETH-USD-PERP",
-		Side:      "SELL",
-		OrderType: "LIMIT",
-		Size:      "2000000000",   // 20 * 10^8
-		Price:     "190000000000", // 1900 * 10^8
-	}
 	priv, err := ecdsa.GenerateKey(rand.Reader)
-	pubX := big.NewInt(0)
-	pubX = priv.PublicKey.A.X.BigInt(pubX)
 	require.NoError(b, err)
-	td, err := NewVerificationTypedData(VerificationTypeOrder, "PRIVATE_SN_POTC_SEPOLIA")
+	td, err := NewVerificationTypedData(VerificationTypeOrder, StarknetChainID)
 	require.NoError(b, err)
 	sc := caigo.StarkCurve{}
 	domEnc, err := td.GetTypedMessageHash("StarkNetDomain", td.Domain, sc)
 	require.NoError(b, err)
-	// x is the Public Key
-	// Replace x with account address
-	// Compute using `ComputeAddress` method in `go/utils.go:40`
 	sum := big.NewInt(0)
 	b.ResetTimer()
 	var sig []byte
 	var hash *big.Int
 	for i := 0; i < b.N; i++ {
-
-		hash, err := GnarkGetMessageHash(td, domEnc, pubX, orderP, sc)
-		// hash2, err := GetMessageHash(td, domEnc, pubX, orderP, sc)
-		// fmt.Println(hash.String(), "\n", hash2.String())
+		hash, err = GnarkGetMessageHash(td, domEnc, testAccountAddress, orderPayload, sc)
 		require.NoError(b, err)
 		sig, err := priv.Sign(hash.Bytes(), nil)
 		require.NoError(b, err)
@@ -189,46 +94,27 @@ func BenchmarkGnarkSignSingleOrder(b *testing.B) {
 		require.Truef(b, valid, "signature is invalid: %v", err)
 		sum = sum.Add(sum, hash)
 	}
-	if hash == nil {
-		return
-	}
 	valid, err := priv.PublicKey.Verify(sig, hash.Bytes(), nil)
 	require.Truef(b, valid, "signature is invalid: %v", err)
 	require.NoError(b, err)
 }
 
 func BenchmarkGnarkVerifySingleOrder(b *testing.B) {
-	orderP := &OrderPayload{
-		Timestamp: 1684815490129,
-		Market:    "ETH-USD-PERP",
-		Side:      "SELL",
-		OrderType: "LIMIT",
-		Size:      "2000000000",   // 20 * 10^8
-		Price:     "190000000000", // 1900 * 10^8
-	}
 	priv, err := ecdsa.GenerateKey(rand.Reader)
-	pubX := big.NewInt(0)
-	pubX = priv.PublicKey.A.X.BigInt(pubX)
 	require.NoError(b, err)
-	td, err := NewVerificationTypedData(VerificationTypeOrder, "PRIVATE_SN_POTC_SEPOLIA")
+	td, err := NewVerificationTypedData(VerificationTypeOrder, StarknetChainID)
 	require.NoError(b, err)
 	sc := caigo.StarkCurve{}
 	domEnc, err := td.GetTypedMessageHash("StarkNetDomain", td.Domain, sc)
 	require.NoError(b, err)
-	// x is the Public Key
-	// Replace x with account address
-	// Compute using `ComputeAddress` method in `go/utils.go:40`
-	hash, err := GetMessageHash(td, domEnc, pubX, orderP, sc)
+	hash, err := GnarkGetMessageHash(td, domEnc, testAccountAddress, orderPayload, sc)
 	require.NoError(b, err)
 	sig, err := priv.Sign(hash.Bytes(), nil)
 	require.NoError(b, err)
 	sum := big.NewInt(0)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-
-		hash, err := GnarkGetMessageHash(td, domEnc, pubX, orderP, sc)
-		// hash2, err := GetMessageHash(td, domEnc, pubX, orderP, sc)
-		// fmt.Println(hash.String(), "\n", hash2.String())
+		hash, err := GnarkGetMessageHash(td, domEnc, testAccountAddress, orderPayload, sc)
 		require.NoError(b, err)
 		valid, err := priv.PublicKey.Verify(sig, hash.Bytes(), nil)
 		require.Truef(b, valid, "signature is invalid: %v", err)


### PR DESCRIPTION
- Fixes garbage collection issues observed for large amount of orders
- `GnarkSign` improves signing speed by `4x` when compared to `caigo.Curve.Sign`
- Add new method to generate `GetEcdsaPrivateKey` from hex string
- Cleanup methods and benchmarks used in `signable_starknet.go`