### PR TITLE
[go] Generate Paradex key pair from Ethereum private key

### DIFF
--- a/go/constants.go
+++ b/go/constants.go
@@ -4,3 +4,4 @@ const PARADEX_HTTP_URL = "https://api.testnet.paradex.trade/v1"
 const CONTENT_TYPE = "application/json"
 
 const DEFAULT_EXPIRY_IN_SECONDS = int64(30)
+const MAINNET_CHAIN_ID = 1

--- a/go/eip712.go
+++ b/go/eip712.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/signer/core/apitypes"
+)
+
+var typesStandard = apitypes.Types{
+	"EIP712Domain": {
+		{
+			Name: "name",
+			Type: "string",
+		},
+		{
+			Name: "version",
+			Type: "string",
+		},
+		{
+			Name: "chainId",
+			Type: "uint256",
+		},
+	},
+	"Constant": {
+		{
+			Name: "action",
+			Type: "string",
+		},
+	},
+}
+
+const primaryType = "Constant"
+
+var domainStandard = apitypes.TypedDataDomain{
+	Name:    "Paradex",
+	Version: "1",
+	ChainId: math.NewHexOrDecimal256(MAINNET_CHAIN_ID),
+}
+
+var messageStandard = map[string]interface{}{
+	"action": "STARK Key",
+}
+
+var typedData = apitypes.TypedData{
+	Types:       typesStandard,
+	PrimaryType: primaryType,
+	Domain:      domainStandard,
+	Message:     messageStandard,
+}
+
+func SignTypedData(typedData apitypes.TypedData, privateKey *ecdsa.PrivateKey) ([]byte, error) {
+	var signature []byte
+
+	hash, err := EncodeForSigning(typedData)
+	if err != nil {
+		return signature, err
+	}
+	signature, err = crypto.Sign(hash.Bytes(), privateKey)
+	if err != nil {
+		return signature, err
+	}
+	signature[64] += 27
+
+	return signature, nil
+}
+
+func EncodeForSigning(typedData apitypes.TypedData) (common.Hash, error) {
+	var hash common.Hash
+
+	domainSeparator, err := typedData.HashStruct("EIP712Domain", typedData.Domain.Map())
+	if err != nil {
+		return hash, err
+	}
+	typedDataHash, err := typedData.HashStruct(typedData.PrimaryType, typedData.Message)
+	if err != nil {
+		return hash, err
+	}
+	rawData := []byte(fmt.Sprintf("\x19\x01%s%s", string(domainSeparator), string(typedDataHash)))
+	hash = common.BytesToHash(crypto.Keccak256(rawData))
+	return hash, nil
+}

--- a/go/signable_starknet_test.go
+++ b/go/signable_starknet_test.go
@@ -89,7 +89,7 @@ func BenchmarkGnarkSignSingleOrder(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		hash, err = GnarkGetMessageHash(td, domEnc, testAccountAddress, orderPayload, sc)
 		require.NoError(b, err)
-		sig, err := priv.Sign(hash.Bytes(), nil)
+		sig, err = priv.Sign(hash.Bytes(), nil)
 		require.NoError(b, err)
 		valid, err := priv.PublicKey.Verify(sig, hash.Bytes(), nil)
 		require.Truef(b, valid, "signature is invalid: %v", err)

--- a/go/utils.go
+++ b/go/utils.go
@@ -1,12 +1,15 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"math/big"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/dontpanicdao/caigo"
 	"github.com/dontpanicdao/caigo/types"
@@ -66,4 +69,48 @@ func ComputeAddress(config SystemConfigResponse, publicKey string) string {
 	}
 	addressHash, _ := caigo.Curve.ComputeHashOnElements(address)
 	return types.BigToHex(addressHash)
+}
+
+func GrindKey(keySeed string, keyValLimit *big.Int) string {
+	sha256EcMaxDigest := new(big.Int)
+	sha256EcMaxDigest.SetString("1 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000", 16)
+	maxAllowedVal := new(big.Int).Sub(sha256EcMaxDigest, new(big.Int).Mod(sha256EcMaxDigest, keyValLimit))
+
+	i := 0
+	key := hashKeyWithIndex(keySeed, i)
+	i++
+
+	// Make sure the produced key is divided by the Stark EC order, and falls within the range
+	// [0, maxAllowedVal).
+	for key.Cmp(maxAllowedVal) < 0 {
+		key = hashKeyWithIndex(keySeed, i)
+		i++
+	}
+
+	// Should this be unsignedMod?
+	result := new(big.Int).Mod(key, keyValLimit)
+	return fmt.Sprintf("0x%x", result)
+}
+
+func hashKeyWithIndex(keySeed string, index int) *big.Int {
+	// Remove '0x' prefix if present
+	key := strings.TrimPrefix(keySeed, "0x")
+
+	// Convert index to hex and pad to 2 bytes
+	indexHex := fmt.Sprintf("%02x", index)
+
+	// Combine key and index
+	data := key + indexHex
+
+	// Decode hex string to bytes
+	dataBytes, err := hex.DecodeString(data)
+	if err != nil {
+		panic(err)
+	}
+
+	// Compute SHA-256 hash
+	hash := sha256.Sum256(dataBytes)
+
+	// Convert hash to big.Int
+	return new(big.Int).SetBytes(hash[:])
 }


### PR DESCRIPTION
👋  Hi there, I saw a TODO in the Go code example to generate Paradex keys from Ethereum private key and thought I could give it a try.

This PR also fixes an issue in test `BenchmarkGnarkSignSingleOrder` function where the signature verification was failing due to a variable scoping problem for `sig`.