### PR TITLE
[go] Use config for the L1 chain Id 

### DIFF
--- a/go/constants.go
+++ b/go/constants.go
@@ -5,3 +5,4 @@ const CONTENT_TYPE = "application/json"
 
 const DEFAULT_EXPIRY_IN_SECONDS = int64(30)
 const MAINNET_CHAIN_ID = 1
+const TESTNET_CHAIN_ID = 11155111

--- a/go/constants.go
+++ b/go/constants.go
@@ -4,5 +4,3 @@ const PARADEX_HTTP_URL = "https://api.testnet.paradex.trade/v1"
 const CONTENT_TYPE = "application/json"
 
 const DEFAULT_EXPIRY_IN_SECONDS = int64(30)
-const MAINNET_CHAIN_ID = 1
-const TESTNET_CHAIN_ID = 11155111

--- a/go/eip712.go
+++ b/go/eip712.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/ecdsa"
 	"fmt"
+	"strconv"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
@@ -35,21 +36,26 @@ var typesStandard = apitypes.Types{
 
 const primaryType = "Constant"
 
-var domainStandard = apitypes.TypedDataDomain{
-	Name:    "Paradex",
-	Version: "1",
-	ChainId: math.NewHexOrDecimal256(MAINNET_CHAIN_ID),
+func domainStandard(chainId string) apitypes.TypedDataDomain {
+	l1Chain, _ := strconv.ParseInt(chainId, 10, 64)
+	return apitypes.TypedDataDomain{
+		Name:    "Paradex",
+		Version: "1",
+		ChainId: math.NewHexOrDecimal256(l1Chain),
+	}
 }
 
 var messageStandard = map[string]interface{}{
 	"action": "STARK Key",
 }
 
-var typedData = apitypes.TypedData{
-	Types:       typesStandard,
-	PrimaryType: primaryType,
-	Domain:      domainStandard,
-	Message:     messageStandard,
+func typedData(chainId string) apitypes.TypedData {
+	return apitypes.TypedData{
+		Types:       typesStandard,
+		PrimaryType: primaryType,
+		Domain:      domainStandard(chainId),
+		Message:     messageStandard,
+	}
 }
 
 func SignTypedData(typedData apitypes.TypedData, privateKey *ecdsa.PrivateKey) ([]byte, error) {

--- a/go/example.go
+++ b/go/example.go
@@ -53,13 +53,7 @@ func GetEthereumAccount() (string, string) {
 // Generate Paradex private key from Ethereum private key
 func GenerateParadexAccount(config SystemConfigResponse, ethPrivateKey string) (string, string, string) {
 	privateKey, _ := crypto.HexToECDSA(ethPrivateKey)
-	l1Chain, _ := strconv.ParseInt(config.L1ChainId, 10, 64)
-
-	// Update the ChainId value in the typedData using config
-	typedData.Domain.ChainId = math.NewHexOrDecimal256(l1Chain)
-
-	ethSignature, _ := SignTypedData(typedData, privateKey)
-
+   ethSignature, _ := SignTypedData(typedData(config.L1ChainId), privateKey)
 	// Convert the first 32 bytes of ethSignature to a hex string
 	r := hex.EncodeToString(ethSignature[:32])
 	// Get Starknet curve order

--- a/go/example.go
+++ b/go/example.go
@@ -18,6 +18,7 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/stark-curve/fr"
 	"github.com/dontpanicdao/caigo"
 	"github.com/dontpanicdao/caigo/types"
+	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
@@ -52,7 +53,13 @@ func GetEthereumAccount() (string, string) {
 // Generate Paradex private key from Ethereum private key
 func GenerateParadexAccount(config SystemConfigResponse, ethPrivateKey string) (string, string, string) {
 	privateKey, _ := crypto.HexToECDSA(ethPrivateKey)
+	l1Chain, _ := strconv.ParseInt(config.L1ChainId, 10, 64)
+
+	// Update the ChainId value in the typedData using config
+	typedData.Domain.ChainId = math.NewHexOrDecimal256(l1Chain)
+
 	ethSignature, _ := SignTypedData(typedData, privateKey)
+
 	// Convert the first 32 bytes of ethSignature to a hex string
 	r := hex.EncodeToString(ethSignature[:32])
 	// Get Starknet curve order

--- a/go/example.go
+++ b/go/example.go
@@ -18,7 +18,6 @@ import (
 	"github.com/consensys/gnark-crypto/ecc/stark-curve/fr"
 	"github.com/dontpanicdao/caigo"
 	"github.com/dontpanicdao/caigo/types"
-	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
@@ -53,7 +52,7 @@ func GetEthereumAccount() (string, string) {
 // Generate Paradex private key from Ethereum private key
 func GenerateParadexAccount(config SystemConfigResponse, ethPrivateKey string) (string, string, string) {
 	privateKey, _ := crypto.HexToECDSA(ethPrivateKey)
-   ethSignature, _ := SignTypedData(typedData(config.L1ChainId), privateKey)
+	ethSignature, _ := SignTypedData(typedData(config.L1ChainId), privateKey)
 	// Convert the first 32 bytes of ethSignature to a hex string
 	r := hex.EncodeToString(ethSignature[:32])
 	// Get Starknet curve order


### PR DESCRIPTION
Currently the go code samples use a pre-defined value in constants.go.  However, this is confusing because that value points to the prod chain despite pulling the config from Testnet by default.

This allows the chain ID to be controlled by the base URL that is used for the rest of the samples making it easier and more flexible.